### PR TITLE
Additional time needed for CLI text dump

### DIFF
--- a/tabs/cli.js
+++ b/tabs/cli.js
@@ -99,7 +99,10 @@ TABS.cli.sendSlowly = function (out_arr, i, timeout_needle) {
         bufView[out_arr[i].length] = 0x0D; // enter (\n)
 
         serial.send(bufferOut);
-    }, timeout_needle * 5);
+        if (out_arr[i].substring(1, 7) == 'profile') {
+            timeout_needle *= 2; // switching profiles needs additional time
+        }
+    }, timeout_needle * 15);
 };
 
 TABS.cli.read = function (readInfo) {


### PR DESCRIPTION
This was discussed in [issue #260](https://github.com/borisbstyle/betaflight/issues/260). When dumping large texts into CLI the buffer does not always keep up and some lines are lost. This PR adds a little extra time after each line that allows FC to keep up. 